### PR TITLE
implemented open url action for end nodes

### DIFF
--- a/data.json
+++ b/data.json
@@ -10,8 +10,8 @@
                         "name": "Merge Sort"
 
                     }, {
-                        "name": "Quicksort"
-
+                        "name": "Quicksort",
+                        "url": "https://en.wikipedia.org/wiki/Quicksort"
                     }, {
                         "name": "Heapsort"
 

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function update(source) {
       .attr("text-anchor", function(d) { return d.children || d._children ? "end" : "start"; })
       .text(function(d) { return d.name; })
       .style("fill-opacity", nodeStartRadius);
-
+      
   // Transition nodes to their new position.
   var nodeUpdate = node.transition()
       .duration(duration)
@@ -172,6 +172,9 @@ function click(d) {
 
     // Set shown children list to null 
     d.children = null;
+  } else if (d._children == null) {
+      // If clicked on end node, open the node's url in a new tab
+      window.open(d.url, '_blank');
   } else { // otherwise, clicked on an unopened node so open it
     // Set shown children to hidden children ("opening" the subtree)
     d.children = d._children;


### PR DESCRIPTION
# End Node Click Action

I implemented the click action for end nodes. It's really simple. In the `click()` function, I added an `else if` that checks if `d._children == null` which just means, check if the node has no more children to show--therefore it is an end node. Then I used the Javascript `window.open()` function to open the node's url in a new tab. 

All we have to do now is add the url attribute to the json file. For reference, I went ahead and added a url for quicksort. 
## What next?

Now that this action is implemented, we can start working on Gist and creating the documents for each end node to link to.
