### PR TITLE
Switched to static links

### DIFF
--- a/data.json
+++ b/data.json
@@ -8,55 +8,55 @@
                     "name": "Sorting",
                     "children": [{
                         "name": "Merge Sort",
-                        "url": "./resources/sorting/merge_sort.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/sorting/merge_sort.md"
                     }, {
                         "name": "Quicksort",
-                        "url": "./resources/sorting/quicksort.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/sorting/quicksort.md"
                     }, {
                         "name": "Heapsort",
-                        "url": "./resources/sorting/heapsort.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/sorting/heapsort.md"
                     }, {
                         "name": "Bucket sort",
-                        "url": "./resources/sorting/bucket_sort.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/sorting/bucket_sort.md"
                     }, {
                         "name": "Radix sort",
-                        "url": "./resources/sorting/radix_sort.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/sorting/radix_sort.md"
                     }, {
                         "name": "Insertion sort",
-                        "url": "./resources/sorting/insertion_sort.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/sorting/insertion_sort.md"
                     }, {
                         "name": "Bubble sort",
-                        "url": "./resources/sorting/bubble_sort.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/sorting/bubble_sort.md"
                     }]
                 }, {
                     "name": "Searching",
                     "children": [{
                         "name": "Linear Search",
-                        "url": "./resources/searching/linear_search.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/searching/linear_search.md"
                     }, {
                         "name": "Binary Search",
-                        "url": "./resources/searching/binary_search.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/searching/binary_search.md"
                     }]
                 }, {
                     "name": "Graph Algorithms",
                     "children": [{
                         "name": "Implementation",
-                        "url": "./resources/graph_algorithms/implementation.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/graph_algorithms/implementation.md"
                     }, {
                         "name": "Breadth First Traversal",
-                        "url": "./resources/graph_algorithms/breadth_first_traversal.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/graph_algorithms/breadth_first_traversal.md"
                     }, {
                         "name": "Depth First Traversal",
-                        "url": "./resources/graph_algorithms/depth_first_traversal.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/graph_algorithms/depth_first_traversal.md"
                     }, {
                         "name": "Dijkstra’s shortest path ",
-                        "url": "./resources/graph_algorithms/dijkstra.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/graph_algorithms/dijkstra.md"
                     }, {
                         "name": "Bellman–Ford Algorithm",
-                        "url": "./resources/graph_algorithms/bellman_ford_algorithm.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/graph_algorithms/bellman_ford_algorithm.md"
                     }, {
                         "name": "Floyd Warshall Algorithm",
-                        "url": "./resources/graph_algorithms/floyd_warshall_algorithm.md"
+                        "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/graph_algorithms/floyd_warshall_algorithm.md"
                     }]
                 },
 
@@ -144,7 +144,7 @@
 
                 }, {
                     "name": "Binary Trees",
-                    "url": "./resources/data_structures/binary_trees.md"
+                    "url": "https://github.com/andersy005/InterviewPrep-Guide/blob/master/resources/data_structures/binary_trees.md"
                 }, {
                     "name": "Binary Search Trees"
                 }, {

--- a/data.json
+++ b/data.json
@@ -7,55 +7,56 @@
             "children": [{
                     "name": "Sorting",
                     "children": [{
-                        "name": "Merge Sort"
-
+                        "name": "Merge Sort",
+                        "url": "./resources/sorting/merge_sort.md"
                     }, {
                         "name": "Quicksort",
-                        "url": "https://en.wikipedia.org/wiki/Quicksort"
+                        "url": "./resources/sorting/quicksort.md"
                     }, {
-                        "name": "Heapsort"
-
+                        "name": "Heapsort",
+                        "url": "./resources/sorting/heapsort.md"
                     }, {
-                        "name": "Bucket sort"
-
+                        "name": "Bucket sort",
+                        "url": "./resources/sorting/bucket_sort.md"
                     }, {
-                        "name": "Radix sort"
-
+                        "name": "Radix sort",
+                        "url": "./resources/sorting/radix_sort.md"
                     }, {
-                        "name": "Insertion sort"
-
+                        "name": "Insertion sort",
+                        "url": "./resources/sorting/insertion_sort.md"
                     }, {
-                        "name": "Bubble sort"
+                        "name": "Bubble sort",
+                        "url": "./resources/sorting/bubble_sort.md"
                     }]
                 }, {
                     "name": "Searching",
                     "children": [{
-                        "name": "Linear Search"
-
+                        "name": "Linear Search",
+                        "url": "./resources/searching/linear_search.md"
                     }, {
-                        "name": "Binary Search"
-
+                        "name": "Binary Search",
+                        "url": "./resources/searching/binary_search.md"
                     }]
                 }, {
                     "name": "Graph Algorithms",
                     "children": [{
-                        "name": "Implementation"
-
+                        "name": "Implementation",
+                        "url": "./resources/graph_algorithms/implementation.md"
                     }, {
-                        "name": "Breadth First Traversal"
-
+                        "name": "Breadth First Traversal",
+                        "url": "./resources/graph_algorithms/breadth_first_traversal.md"
                     }, {
-                        "name": "Depth First Traversal"
-
+                        "name": "Depth First Traversal",
+                        "url": "./resources/graph_algorithms/depth_first_traversal.md"
                     }, {
-                        "name": "Dijkstra’s shortest path "
-
+                        "name": "Dijkstra’s shortest path ",
+                        "url": "./resources/graph_algorithms/dijkstra.md"
                     }, {
-                        "name": "Bellman–Ford Algorithm"
-
+                        "name": "Bellman–Ford Algorithm",
+                        "url": "./resources/graph_algorithms/bellman_ford_algorithm.md"
                     }, {
-                        "name": "Floyd Warshall Algorithm"
-
+                        "name": "Floyd Warshall Algorithm",
+                        "url": "./resources/graph_algorithms/floyd_warshall_algorithm.md"
                     }]
                 },
 


### PR DESCRIPTION
I changed the current links in _data.json_ to static links instead of the old relative links. This is so that the new tab will show the markdown file in GitHub, where it will style the markdown appropriately, as opposed to showing the raw markdown text in the browser (an issue of using GitHub Pages).

**Note**:
In the future, if we wanted, we could change back to relative links and add a style sheet for the markdown. For now though, this is the best solution, I believe.
